### PR TITLE
Make length 1 for a single frame PWM.

### DIFF
--- a/hw/drivers/pwm/pwm_nrf52/src/pwm_nrf52.c
+++ b/hw/drivers/pwm/pwm_nrf52/src/pwm_nrf52.c
@@ -208,7 +208,7 @@ play_current_config(struct nrf53_pwm_dev_global *instance)
     nrf_pwm_sequence_t const seq =
         {
             .values.p_individual = instance->duty_cycles,
-            .length              = 4,
+            .length              = 1,
             .repeats             = 0,
             .end_delay           = 0
         };

--- a/hw/mcu/nordic_sdk/src/ext/nRF5_SDK_11.0.0_89a8197/components/drivers_nrf/rtc/nrf_drv_rtc.c
+++ b/hw/mcu/nordic_sdk/src/ext/nRF5_SDK_11.0.0_89a8197/components/drivers_nrf/rtc/nrf_drv_rtc.c
@@ -26,7 +26,6 @@ typedef struct
 // User callbacks local storage.
 static nrf_drv_rtc_handler_t m_handlers[RTC_COUNT];
 static nrf_drv_rtc_cb_t      m_cb[RTC_COUNT];
-
 static const nrf_drv_rtc_config_t m_default_config[] = {
 #if RTC0_ENABLED
     NRF_DRV_RTC_DEFAULT_CONFIG(0),


### PR DESCRIPTION
Given the implementation of the higher level PWM functions, specifically pwm_enable_duty_cycle, this appears to be erroneous, as it will cause 1 cycle in which the PWM duty is correct, and 3 cycles where it is either completely on or off depending on the configured polarity.

I have not tested this against any other use cases than having only one pin configured with a single, static, looped duty cycle. 